### PR TITLE
Bump version to 0.2 and set latest dependencies

### DIFF
--- a/lib/rom/neo4j/version.rb
+++ b/lib/rom/neo4j/version.rb
@@ -1,5 +1,5 @@
 module ROM
   module Neo4j
-    VERSION = '0.1.1'.freeze
+    VERSION = '0.2.0'.freeze
   end
 end

--- a/rom-neo4j.gemspec
+++ b/rom-neo4j.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rom', '~> 0.8', '>= 0.8.0'
-  spec.add_runtime_dependency 'neo4j-core', '4.0.1'
+  spec.add_runtime_dependency 'rom', '~> 0.9', '>= 0.9.1'
+  spec.add_runtime_dependency 'neo4j-core', '5.1.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Use the latest version of the Neo4j Gem and remove references to ROM 0.8 from the gemspec.