### PR TITLE
Remove Dataset class, allow raw Cypher queries

### DIFF
--- a/lib/rom/neo4j/gateway.rb
+++ b/lib/rom/neo4j/gateway.rb
@@ -8,10 +8,8 @@ module ROM
         @connection = ::Neo4j::Session.open(:server_db, uri, options)
       end
 
-      def dataset(spec)
-        %i[ start match return ].reduce(@connection.query) do |query, clause|
-          spec[clause] ? query.send(clause, spec[clause] : query
-        end
+      def dataset(dataset)
+        @connection.query
       end
 
     end

--- a/lib/rom/neo4j/gateway.rb
+++ b/lib/rom/neo4j/gateway.rb
@@ -3,20 +3,17 @@ require 'rom/gateway'
 module ROM
   module Neo4j
     class Gateway < ROM::Gateway
-      attr_reader :sets
 
-      def initialize(uri, options={})
+      def initialize(uri=nil, options={})
         @connection = ::Neo4j::Session.open(:server_db, uri, options)
-        @sets = {}
       end
 
-      def dataset(name)
-        sets[name] = Dataset.new(@connection.query)
+      def dataset(spec)
+        %i[ start match return ].reduce(@connection.query) do |query, clause|
+          spec[clause] ? query.send(clause, spec[clause] : query
+        end
       end
 
-      def dataset?(name)
-        sets.key?(name)
-      end
     end
   end
 end

--- a/lib/rom/neo4j/gateway.rb
+++ b/lib/rom/neo4j/gateway.rb
@@ -9,7 +9,10 @@ module ROM
       end
 
       def dataset(dataset)
-        @connection.query
+        case dataset
+        when String then @connection.query(dataset)
+        else @connection.query
+        end
       end
 
     end

--- a/lib/rom/neo4j/relation.rb
+++ b/lib/rom/neo4j/relation.rb
@@ -1,97 +1,29 @@
 module ROM
   module Neo4j
     # Relation supporting Cypher graph traversals. Configure the sub-graph
-    # for the relation by specifying a `match` pattern, and collect a dataset
+    # for the relation using the Cypher Query DSL from 
     # for mapping by specifying nodes, edges and properties in the `returns`.
     class Relation < ROM::Relation
       adapter :neo4j
 
-      # TODO: document these methods
-      forward(
-        :start, :match, :where, :return, :limit, :merge, :order,
-        :optional_match, :params
-      )
+      # TODO: provide reference to Neo4j Cypher DSL docs?
+      forward *%i[
+        break create create_unique delete limit match merge on_create_set
+        on_match_set optional_match order remove return set start union_cypher
+        unwind using where with
+      ]
+
+      # TODO support passing raw Cypher here-- current holdup is that query
+      # objects created with raw Cypher give a Node/Rel enumerator, which is
+      # different than the hash enumerator we want
+      def self.cypher(&cypher_dsl)
+        dataset(&cypher_dsl)
+      end
 
       # The row iterator. Calling this kicks off the actual query to the
       # database server.
-      #
-      # Before triggering the enumerator, it rebuilds the dataset with the
-      # default traversal configured by the relation DSL.
-      #
       def each(&iter)
-        # Configure the default traversal
-        unless @configured
-          @configured = true
-          self.class.traversal.each do |query_method, conditions|
-            @dataset = @dataset.send(query_method.to_sym, *conditions) if conditions
-          end
-        end
-
         @dataset.each(&iter)
-      end
-
-      # Builds data structures to configure the relation DSL.
-      # @api private
-      def self.inherited(klass)
-        klass.class_eval do
-          class << self
-            attr_reader :traversal
-          end
-        end
-
-        klass.instance_variable_set('@traversal', {
-          start: false,
-          match: false,
-          return: false
-        })
-
-        super
-      end
-
-      # Specify a `START` node for the for the relation's graph traversal. This
-      # is only required for legacy indexes. In most cases Cypher can infer the
-      # starting points to anchor a graph traversal from the pattern specified
-      # in a `MATCH` clause.
-      #
-      # @see http://neo4j.com/docs/stable/query-start.html
-      #
-      def self.start(*conditions)
-        @traversal[:start] = conditions
-      end
-
-      # Specify a `MATCH` clause for the relation's graph traversal. If you’re
-      # coming from the SQL world, you can think of this as similar to a
-      # `SELECT FROM`, except that it matches on a topological structure rather
-      # than a schema.
-      #
-      # @example Reproduce SQL style projections by passing node labels directly.
-      #
-      #   class Movies < ROM::Relation[:neo4j]
-      #     matches m: :movie
-      #   end
-      #
-      # @example Specify topological matches using Cypher's ASCII-art syntax.
-      #
-      #   class Actors < ROM::Relation[:neo4j]
-      #     matches '(actor:Person)-[:ACTED_IN]->(movie)'
-      #   end
-      #
-      # @see http://neo4j.com/docs/stable/query-match.html
-      #
-      def self.matches(*conditions)
-        @traversal[:match] = conditions
-      end
-
-      # Specify a `RETURN` clause for the relation. This will define the
-      # structure of objects in the returned dataset.
-      #
-      # Any combination of nodes, edges and properties can be selected, as well
-      # as custom aliases and distinct objects.
-      #
-      # @see http://neo4j.com/docs/stable/query-return.html
-      #
-      def self.returns(*conditions)
-        @traversal[:return] = conditions
       end
 
     end

--- a/lib/rom/neo4j/relation.rb
+++ b/lib/rom/neo4j/relation.rb
@@ -4,7 +4,12 @@ module ROM
     # for the relation using the Cypher Query DSL from 
     # for mapping by specifying nodes, edges and properties in the `returns`.
     class Relation < ROM::Relation
+
       adapter :neo4j
+
+      def self.cypher(query=nil, &dsl)
+        dataset(query, &dsl)
+      end
 
       # TODO: provide reference to Neo4j Cypher DSL docs?
       forward *%i[
@@ -12,13 +17,6 @@ module ROM
         on_match_set optional_match order remove return set start union_cypher
         unwind using where with
       ]
-
-      # TODO support passing raw Cypher here-- current holdup is that query
-      # objects created with raw Cypher give a Node/Rel enumerator, which is
-      # different than the hash enumerator we want
-      def self.cypher(&cypher_dsl)
-        dataset(&cypher_dsl)
-      end
 
       # The row iterator. Calling this kicks off the actual query to the
       # database server.

--- a/lib/rom/neo4j/support/core_ext.rb
+++ b/lib/rom/neo4j/support/core_ext.rb
@@ -1,11 +1,16 @@
 # Extensions to the Neo4j::Core library making it easier to integrate with ROM.
+
+# TODO (2015-11-22) Neo4j core is being updated to 6.0.0 soon-- we are working
+# to expose an API so that this functionality can be achieved without the below
+# monkey patches, so this whole section should be regarded as temporary.
+
 module Neo4j
   module Core
     UnsupportedDriver = Class.new(StandardError)
 
-    # DSL for generating Cypher queries and enumerating their results.
-    #
-    # @see http://www.rubydoc.info/gems/neo4j-core/Neo4j/Core/Query
+    # This patches Query so that it returns Hashes rather than Neo4j::Node
+    # objects. We don't want Neo4j::Nodes in our Relations
+
     class Query
       # Exports the underlying session handle.
       # @return [Neo4j::Session]
@@ -26,5 +31,33 @@ module Neo4j
         end
       end
     end
+
   end
+
+  # Has the same effect as the above patch to query, except this makes
+  # CypherSession#query return hashes instead of nodes. The practical effect is
+  # that you now get Hashes whether you pass a raw Cypher string or use the
+  # Cypher DSL with CypherSession#query.
+
+  module Server
+
+    class CypherSession < Neo4j::Session
+
+      alias_method :original_query, :query
+
+      def query(*args)
+        if args.first.is_a?(String)
+          query, params = args[0,2]
+          response = _query(query, params)
+          response.raise_error if response.error?
+          response.to_struct_enumeration(query)
+        else
+          original_query(*args)
+        end
+      end
+
+    end
+
+  end
+
 end

--- a/rom-neo4j.gemspec
+++ b/rom-neo4j.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rom', '~> 0.9', '>= 0.9.1'
-  spec.add_runtime_dependency 'neo4j-core', '5.1.3'
+  spec.add_runtime_dependency 'rom', '>= 0.9.1'
+  spec.add_runtime_dependency 'neo4j-core', '>=5.1.3'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
- removed `Dataset` class. `ROM::Neo4j::Dataset` seemed to have been inspired by the ROM::SQL adapter, but from what I could tell it was redundant-- all it did was forward methods to an underlying `Neo4j::Core::Query`. Since `Dataset` was not user-facing anyway, I saw no reason to maintain it; now, Neo4j::Query objects are used as the "datasets". The full Cypher DSL is also now forwarded from relation to the underlying dataset as well.
- changed the dataset specification API so that now you just call `Relation::dataset` and pass either a string (Cypher query) or a block. Inside the block, you have access to the full Cypher query DSL. To make raw strings work, I had to expand the monkey patch. However, I think we will be able to get rid of the monkey patch in the future. I've been in contact with the Neo4j::Core maintainers and there is an open issue (https://github.com/neo4jrb/neo4j-core/issues/223) for controlling whether the results of `Query#each` are wrapped in `Node` objects (and the purpose of the monkey patch is to prevent said wrapping)

``` ruby
class Users < ROM::Relation[:neo4j]

  dataset do
    match('(n:users)').return(:n)
  end

end

# or

class Users < ROM::Relation[:neo4j]

  dataset "MATCH (n:users) RETURN n"

end
```

These changes are documented in commit messages.
